### PR TITLE
Add side-by-side view for SHACL shapes graph and data graph

### DIFF
--- a/shacl-extension/README.md
+++ b/shacl-extension/README.md
@@ -10,6 +10,7 @@ The SHACL Shapes Editor extension provides a user-friendly interface for authori
 - Edit existing SHACL Shapes
 - Visualize SHACL Shapes
 - Validate RDF graphs against SHACL Shapes
+- Side-by-side view of SHACL shapes graph and data graph with visual indication of violating triples
 
 ## Installation
 
@@ -37,6 +38,14 @@ The SHACL Shapes Editor extension provides a user-friendly interface for authori
 1. Open the RDF graph document you want to validate.
 2. Open the SHACL Shape document you want to use for validation.
 3. Run the validation command from the Command Palette.
+
+### Side-by-Side View of SHACL Shapes Graph and Data Graph
+
+1. Open the Command Palette by pressing `Ctrl+Shift+P`.
+2. Type "Show Side-by-Side View" and select the command.
+3. Select the SHACL shapes graph document.
+4. Select the data graph document.
+5. The two documents will be opened side-by-side with visual indication of violating triples in the data graph.
 
 ## Examples
 

--- a/shacl-extension/package.json
+++ b/shacl-extension/package.json
@@ -10,7 +10,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:shaclExtension.createShape"
+    "onCommand:shaclExtension.createShape",
+    "onCommand:shaclExtension.showSideBySideView"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -18,6 +19,10 @@
       {
         "command": "shaclExtension.createShape",
         "title": "Create SHACL Shape"
+      },
+      {
+        "command": "shaclExtension.showSideBySideView",
+        "title": "Show Side-by-Side View"
       }
     ]
   },

--- a/shacl-extension/src/extension.ts
+++ b/shacl-extension/src/extension.ts
@@ -97,4 +97,82 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     context.subscriptions.push(showFocusNodesCommand);
+
+    const showSideBySideViewCommand = vscode.commands.registerCommand('shaclExtension.showSideBySideView', async () => {
+        const shapeDocument = await vscode.window.showOpenDialog({ filters: { 'Turtle Files': ['ttl'] } });
+        if (!shapeDocument || shapeDocument.length === 0) {
+            return;
+        }
+
+        const dataDocument = await vscode.window.showOpenDialog({ filters: { 'Turtle Files': ['ttl'] } });
+        if (!dataDocument || dataDocument.length === 0) {
+            return;
+        }
+
+        const shapeEditor = await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(shapeDocument[0]), { viewColumn: vscode.ViewColumn.One });
+        const dataEditor = await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(dataDocument[0]), { viewColumn: vscode.ViewColumn.Two });
+
+        const shapeContent = fs.readFileSync(shapeDocument[0].fsPath, 'utf8');
+        const dataContent = fs.readFileSync(dataDocument[0].fsPath, 'utf8');
+
+        const shapeGraph = rdf.dataset().import(rdf.parse(shapeContent));
+        const dataGraph = rdf.dataset().import(rdf.parse(dataContent));
+
+        const validationReport = await rdf.validate(dataGraph, shapeGraph);
+
+        if (!validationReport.conforms) {
+            const decorationType = vscode.window.createTextEditorDecorationType({
+                backgroundColor: 'rgba(255,0,0,0.3)'
+            });
+
+            const ranges = validationReport.results.map(result => {
+                return new vscode.Range(
+                    new vscode.Position(result.focusNode.line - 1, result.focusNode.column - 1),
+                    new vscode.Position(result.focusNode.line - 1, result.focusNode.column - 1 + result.focusNode.length)
+                );
+            });
+
+            dataEditor.setDecorations(decorationType, ranges);
+        }
+
+        const updateViews = async () => {
+            const updatedShapeContent = shapeEditor.document.getText();
+            const updatedDataContent = dataEditor.document.getText();
+
+            const updatedShapeGraph = rdf.dataset().import(rdf.parse(updatedShapeContent));
+            const updatedDataGraph = rdf.dataset().import(rdf.parse(updatedDataContent));
+
+            const updatedValidationReport = await rdf.validate(updatedDataGraph, updatedShapeGraph);
+
+            if (!updatedValidationReport.conforms) {
+                const updatedRanges = updatedValidationReport.results.map(result => {
+                    return new vscode.Range(
+                        new vscode.Position(result.focusNode.line - 1, result.focusNode.column - 1),
+                        new vscode.Position(result.focusNode.line - 1, result.focusNode.column - 1 + result.focusNode.length)
+                    );
+                });
+
+                dataEditor.setDecorations(decorationType, updatedRanges);
+            } else {
+                dataEditor.setDecorations(decorationType, []);
+            }
+        };
+
+        const shapeDocumentChangeSubscription = vscode.workspace.onDidChangeTextDocument(event => {
+            if (event.document.uri.fsPath === shapeDocument[0].fsPath) {
+                updateViews();
+            }
+        });
+
+        const dataDocumentChangeSubscription = vscode.workspace.onDidChangeTextDocument(event => {
+            if (event.document.uri.fsPath === dataDocument[0].fsPath) {
+                updateViews();
+            }
+        });
+
+        context.subscriptions.push(shapeDocumentChangeSubscription);
+        context.subscriptions.push(dataDocumentChangeSubscription);
+    });
+
+    context.subscriptions.push(showSideBySideViewCommand);
 }


### PR DESCRIPTION
Add a side-by-side view of the SHACL shapes graph and the data graph with visual indication of violating triples.

* Add a new command `shaclExtension.showSideBySideView` to `shacl-extension/package.json` to display the side-by-side view.
* Update the usage section in `shacl-extension/README.md` to include instructions for the new side-by-side view feature.
* Implement the `showSideBySideView` command in `shacl-extension/src/extension.ts` to open two editors side-by-side, one for the SHACL shapes graph and one for the data graph.
* Add visual indication of violating triples in the data graph editor using `vscode.TextEditorDecorationType` in `shacl-extension/src/extension.ts`.
* Synchronize the SHACL shapes graph and the data graph views using `vscode.workspace.onDidChangeTextDocument` in `shacl-extension/src/extension.ts`.

